### PR TITLE
Added get_archive_page_id method to breadcrumbs Manager

### DIFF
--- a/src/Breadcrumbs/Manager.php
+++ b/src/Breadcrumbs/Manager.php
@@ -34,6 +34,13 @@ class Manager {
 	}
 
 	/**
+	 * @return int
+	 */
+	public function get_archive_page_id() {
+		return $this->archive_page_id;
+	}
+
+	/**
 	 * Get the breadcrumb string
 	 *
 	 * @return string


### PR DESCRIPTION
I want to modify breadcrumbs in an extension and need the `archive_page_id` to create a new `Crumbs` object.