### PR TITLE
Category name should be lowercase and hyphenated

### DIFF
--- a/src/ArticleList.php
+++ b/src/ArticleList.php
@@ -85,7 +85,7 @@ class ArticleList {
 			}
 
 			// add useful css class
-			$css_classes .= ' wpkb-list-category-' . $args['category'];
+			$css_classes .= 'wpkb-list-category-' . $args['category'];
 			// strip off accents (assuming utf8 PHP - note strtr() requires single-byte)
 			$css_classes = utf8_decode( $css_classes );
 			// convert to lower case

--- a/src/ArticleList.php
+++ b/src/ArticleList.php
@@ -86,6 +86,17 @@ class ArticleList {
 
 			// add useful css class
 			$css_classes .= ' wpkb-list-category-' . $args['category'];
+			// strip off accents (assuming utf8 PHP - note strtr() requires single-byte)
+			$css_classes = utf8_decode( $css_classes );
+			// convert to lower case
+			$css_classes = strtolower( $css_classes );
+			// strip all but alphanumeric, whitespace, dot, underscore, hyphen
+			$css_classes = preg_replace( "/[^a-z0-9\s._-]/", "", $css_classes );
+			// merge multiple consecutive whitespaces, dots, underscores, hyphens
+			$css_classes = preg_replace( "/[\s._-]+/", " ", $css_classes );
+			// convert whitespaces to hyphens
+			$css_classes = preg_replace( "/[\s]/", "-", $css_classes );
+
 		}
 
 		// query by keyword?


### PR DESCRIPTION
When you’re adding a shortcode like `[wpkb_list category="WUT CAtegoRy"
title="What Category Is This?!"]` the CSS being outputted based on the category name should be in lowercase and hyphenated.

This fixes that, though this may not be the smartest way to do this. Feel free to completely ignore this PR and fix this way smarter :)